### PR TITLE
Fix error by json when running start.py

### DIFF
--- a/controller/base_controller.py
+++ b/controller/base_controller.py
@@ -74,7 +74,7 @@ class BaseController(ControllerMixin):
             run_info = run_info.get('RunInfo')
 
             for output_name,run_info_json in run_info.items():
-                _run_info = json.loads(run_info_json)
+                _run_info = json.loads(run_info_json.decode("utf-8"))
                 if _run_info['OK'] is not True:
                     raise Exception('Judge Failed')
                 if _run_info['Signaled'] is True:

--- a/provider/problem_provider.py
+++ b/provider/problem_provider.py
@@ -1,5 +1,6 @@
 from dto import ProblemMetadata
 from os import path
+import os
 import glob
 import json
 
@@ -38,7 +39,9 @@ class ProblemProvider:
         problem_metadata.inputs = inputs
         problem_metadata.outputs = outputs
 
-        problem_limits = json.loads(open(dir_path+"/problem_info.json", "r").read())
+        with open(os.path.join(dir_path,"problem_info.json")) as f:
+            problem_limits = json.load(f)
+
         problem_metadata.time_limit = problem_limits["TimeLimit"]
         problem_metadata.memory_limit = problem_limits["MemoryLimit"]
         return problem_metadata


### PR DESCRIPTION
`python ./start.py -s ./samples/02/solution.cc -l cpp -p 02`
을 실행했을 때 `json object must be str not 'bytes'` 오류가 발생해서
run_info_json 을 decode 하도록 했습니다.

그리고 파일에서 직접 읽어드릴때는 `json.load` 를 쓰는게 좋을 것 같아 바꿨습니다.